### PR TITLE
feat: better sleep timer, closes #446

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -300,6 +300,7 @@
 		<item quantity="other">%1$d lines selected</item>
 	</plurals>
 
+	<string name="action_start">Start</string>
 	<string name="action_ok">OK</string>
 	<string name="action_play">Play</string>
 	<string name="action_next_song">Next song</string>
@@ -323,7 +324,13 @@
 	<string name="action_cancel_download">Cancel download</string>
 	<string name="action_sleep_timer">Sleep timer</string>
 	<string name="action_sleep_timer_enabled">Sleep timer - %1$s left </string>
+	<string name="action_sleep_timer_songs_enabled">Sleep timer - %1$d songs left</string>
+	<string name="action_sleep_timer_queue_enabled">Sleep timer - end of queue</string>
+	<string name="action_sleep_timer_songs">Stop after %1$d songs</string>
+	<string name="action_sleep_timer_queue">Stop at end of current queue</string>
 	<string name="action_disable_sleep_timer">Turn off timer</string>
+	<string name="title_sleep_timer_time">Time</string>
+	<string name="title_sleep_timer_songs">Songs</string>
 	<string name="option_playback_speed">Playback speed</string>
 	<string name="action_navigate_back">Navigate up</string>
 	<string name="action_log_out">Logout</string>

--- a/composeApp/src/commonMain/kotlin/paige/navic/domain/manager/SleepTimerManager.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/domain/manager/SleepTimerManager.kt
@@ -6,38 +6,103 @@ import kotlinx.coroutines.IO
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import paige.navic.shared.MediaPlayerViewModel
 import kotlin.time.Clock
 import kotlin.time.Duration
 import kotlin.time.Instant
 
+sealed interface SleepTimerMode {
+	data object Disabled : SleepTimerMode
+	data class Time(val endTime: Instant) : SleepTimerMode
+	data class Songs(val remaining: Int) : SleepTimerMode
+	data object EndOfQueue : SleepTimerMode
+}
+
 class SleepTimerManager(
 	private val player: MediaPlayerViewModel
 ) {
 	private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 	private var job: Job? = null
-	var endTimeStamp: Instant? = null
-		private set
+	private var observerJob: Job? = null
+	private var remainingSongs = 0
+
+	private val _mode = MutableStateFlow<SleepTimerMode>(SleepTimerMode.Disabled)
+	val mode = _mode.asStateFlow()
+
+	val endTimeStamp: Instant?
+		get() = (mode.value as? SleepTimerMode.Time)?.endTime
 
 	val timeLeft: Duration?
 		get() = endTimeStamp?.let { it - Clock.System.now() }
 
 	fun startTimer(duration: Duration) {
-		job?.cancel()
+		stopTimer()
+		val endTime = Clock.System.now() + duration
+		_mode.value = SleepTimerMode.Time(endTime)
 
 		job = scope.launch {
-			endTimeStamp = Clock.System.now() + duration
-
 			delay(duration)
 			player.pause()
 			stopTimer()
 		}
 	}
 
+	fun startSongsTimer(count: Int) {
+		stopTimer()
+		remainingSongs = count
+		_mode.value = SleepTimerMode.Songs(count)
+		observeSongs()
+	}
+
+	fun startEndOfQueueTimer() {
+		stopTimer()
+		val state = player.uiState.value
+		remainingSongs = if (state.currentIndex != -1) {
+			state.queue.size - state.currentIndex
+		} else {
+			0
+		}
+
+		if (remainingSongs > 0) {
+			_mode.value = SleepTimerMode.EndOfQueue
+			observeSongs()
+		}
+	}
+
+	private fun observeSongs() {
+		observerJob?.cancel()
+		observerJob = scope.launch {
+			player.uiState
+				.map { it.currentIndex }
+				.distinctUntilChanged()
+				.drop(1)
+				.collect {
+					remainingSongs--
+					if (remainingSongs <= 0) {
+						player.pause()
+						stopTimer()
+					} else {
+						val currentMode = _mode.value
+						if (currentMode is SleepTimerMode.Songs) {
+							_mode.value = SleepTimerMode.Songs(remainingSongs)
+						}
+					}
+				}
+		}
+	}
+
 	fun stopTimer() {
 		job?.cancel()
 		job = null
-		endTimeStamp = null
+		observerJob?.cancel()
+		observerJob = null
+		remainingSongs = 0
+		_mode.value = SleepTimerMode.Disabled
 	}
 }

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/components/common/OptionCard.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/components/common/OptionCard.kt
@@ -1,0 +1,68 @@
+package paige.navic.ui.components.common
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun OptionCard(
+	label: String,
+	icon: ImageVector,
+	onClick: () -> Unit,
+	modifier: Modifier = Modifier,
+	isActive: Boolean = false
+) {
+	val containerColor = if (isActive) {
+		MaterialTheme.colorScheme.primaryContainer
+	} else {
+		MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+	}
+	val contentColor = if (isActive) {
+		MaterialTheme.colorScheme.onPrimaryContainer
+	} else {
+		MaterialTheme.colorScheme.onSurfaceVariant
+	}
+
+	Surface(
+		modifier = modifier
+			.clip(MaterialTheme.shapes.medium)
+			.clickable(onClick = onClick),
+		color = containerColor,
+		contentColor = contentColor,
+		shape = MaterialTheme.shapes.medium
+	) {
+		Column(
+			modifier = Modifier.padding(16.dp),
+			horizontalAlignment = Alignment.CenterHorizontally,
+			verticalArrangement = Arrangement.Center
+		) {
+			Icon(
+				imageVector = icon,
+				contentDescription = null,
+				modifier = Modifier.size(24.dp)
+			)
+			Spacer(Modifier.height(8.dp))
+			Text(
+				text = label,
+				style = MaterialTheme.typography.labelLarge,
+				textAlign = TextAlign.Center,
+				maxLines = 1
+			)
+		}
+	}
+}

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/components/common/OptionCard.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/components/common/OptionCard.kt
@@ -1,10 +1,7 @@
 package paige.navic.ui.components.common
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
@@ -39,24 +36,22 @@ fun OptionCard(
 	}
 
 	Surface(
-		modifier = modifier
-			.clip(MaterialTheme.shapes.medium)
-			.clickable(onClick = onClick),
+		modifier = modifier.clip(MaterialTheme.shapes.medium),
 		color = containerColor,
 		contentColor = contentColor,
-		shape = MaterialTheme.shapes.medium
+		shape = MaterialTheme.shapes.medium,
+		onClick = onClick
 	) {
 		Column(
 			modifier = Modifier.padding(16.dp),
 			horizontalAlignment = Alignment.CenterHorizontally,
-			verticalArrangement = Arrangement.Center
+			verticalArrangement = Arrangement.spacedBy(8.dp),
 		) {
 			Icon(
 				imageVector = icon,
 				contentDescription = null,
 				modifier = Modifier.size(24.dp)
 			)
-			Spacer(Modifier.height(8.dp))
 			Text(
 				text = label,
 				style = MaterialTheme.typography.labelLarge,

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/components/sheets/AccountSheet.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/components/sheets/AccountSheet.kt
@@ -20,7 +20,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
@@ -28,6 +27,7 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.kyant.capsule.ContinuousCapsule
 import com.russhwolf.settings.Settings
 import kotlinx.coroutines.launch
@@ -66,7 +66,7 @@ fun AccountSheet(
 
 	var sleepTimerSheetOpen by rememberSaveable { mutableStateOf(false) }
 	val sleepTimerManager = koinInject<SleepTimerManager>()
-	val sleepTimerMode by sleepTimerManager.mode.collectAsState()
+	val sleepTimerMode by sleepTimerManager.mode.collectAsStateWithLifecycle()
 
 	val sheetState = rememberBottomSheetState(
 		initialValue = SheetValue.Hidden,

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/components/sheets/AccountSheet.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/components/sheets/AccountSheet.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.material3.surfaceColorAtElevation
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
@@ -34,12 +35,15 @@ import navic.composeapp.generated.resources.Res
 import navic.composeapp.generated.resources.action_log_out
 import navic.composeapp.generated.resources.action_sleep_timer
 import navic.composeapp.generated.resources.action_sleep_timer_enabled
+import navic.composeapp.generated.resources.action_sleep_timer_queue_enabled
+import navic.composeapp.generated.resources.action_sleep_timer_songs_enabled
 import navic.composeapp.generated.resources.action_view_shares
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import paige.navic.LocalNavStack
 import paige.navic.domain.manager.LoginManager
 import paige.navic.domain.manager.SleepTimerManager
+import paige.navic.domain.manager.SleepTimerMode
 import paige.navic.icons.Icons
 import paige.navic.icons.outlined.Bedtime
 import paige.navic.icons.outlined.Logout
@@ -62,7 +66,7 @@ fun AccountSheet(
 
 	var sleepTimerSheetOpen by rememberSaveable { mutableStateOf(false) }
 	val sleepTimerManager = koinInject<SleepTimerManager>()
-	val sleepTimerLeft = sleepTimerManager.timeLeft
+	val sleepTimerMode by sleepTimerManager.mode.collectAsState()
 
 	val sheetState = rememberBottomSheetState(
 		initialValue = SheetValue.Hidden,
@@ -159,17 +163,31 @@ fun AccountSheet(
 					contentPadding = contentPadding,
 					color = color
 				) {
-					if (sleepTimerLeft != null) {
+					val isEnabled = sleepTimerMode !is SleepTimerMode.Disabled
+					if (isEnabled) {
 						Icon(
 							imageVector = Icons.Outlined.Bedtime,
 							contentDescription = null,
 							tint = MaterialTheme.colorScheme.positive
 						)
 						Text(
-							text = stringResource(
-								resource = Res.string.action_sleep_timer_enabled,
-								sleepTimerLeft.label()
-							),
+							text = when (val mode = sleepTimerMode) {
+								is SleepTimerMode.Time -> stringResource(
+									Res.string.action_sleep_timer_enabled,
+									sleepTimerManager.timeLeft?.label() ?: ""
+								)
+
+								is SleepTimerMode.Songs -> stringResource(
+									Res.string.action_sleep_timer_songs_enabled,
+									mode.remaining
+								)
+
+								is SleepTimerMode.EndOfQueue -> stringResource(
+									Res.string.action_sleep_timer_queue_enabled
+								)
+
+								else -> ""
+							},
 							color = MaterialTheme.colorScheme.positive,
 							modifier = Modifier.weight(1f)
 						)

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/components/sheets/SleepTimerSheet.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/components/sheets/SleepTimerSheet.kt
@@ -18,21 +18,22 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import navic.composeapp.generated.resources.Res
 import navic.composeapp.generated.resources.action_disable_sleep_timer
 import navic.composeapp.generated.resources.action_sleep_timer
@@ -54,6 +55,11 @@ import paige.navic.util.core.label
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 
+enum class SleepTimerTab {
+	TIME,
+	SONGS
+}
+
 val durations = listOf(
 	5.minutes,
 	10.minutes,
@@ -71,13 +77,13 @@ fun SleepTimerSheet(
 	onDismissRequest: (confirmed: Boolean) -> Unit
 ) {
 	val sleepTimerManager = koinInject<SleepTimerManager>()
-	val currentMode by sleepTimerManager.mode.collectAsState()
+	val currentMode by sleepTimerManager.mode.collectAsStateWithLifecycle()
 
-	var selectedTab by remember(currentMode) {
-		mutableIntStateOf(
+	var selectedTab by rememberSaveable(currentMode) {
+		mutableStateOf(
 			when (currentMode) {
-				is SleepTimerMode.Songs, SleepTimerMode.EndOfQueue -> 1
-				else -> 0
+				is SleepTimerMode.Songs, SleepTimerMode.EndOfQueue -> SleepTimerTab.SONGS
+				else -> SleepTimerTab.TIME
 			}
 		)
 	}
@@ -110,73 +116,76 @@ fun SleepTimerSheet(
 			)
 
 			PrimaryTabRow(
-				selectedTabIndex = selectedTab,
+				selectedTabIndex = selectedTab.ordinal,
 				containerColor = Color.Transparent,
 				divider = {}
 			) {
 				Tab(
-					selected = selectedTab == 0,
-					onClick = { selectedTab = 0 },
+					selected = selectedTab == SleepTimerTab.TIME,
+					onClick = { selectedTab = SleepTimerTab.TIME },
 					text = { Text(stringResource(Res.string.title_sleep_timer_time)) }
 				)
 				Tab(
-					selected = selectedTab == 1,
-					onClick = { selectedTab = 1 },
+					selected = selectedTab == SleepTimerTab.SONGS,
+					onClick = { selectedTab = SleepTimerTab.SONGS },
 					text = { Text(stringResource(Res.string.title_sleep_timer_songs)) }
 				)
 			}
 
-			if (selectedTab == 0) {
-				FlowRow(
-					modifier = Modifier.padding(horizontal = 16.dp),
-					horizontalArrangement = Arrangement.spacedBy(8.dp),
-					verticalArrangement = Arrangement.spacedBy(8.dp),
-					maxItemsInEachRow = 3
-				) {
-					durations.forEach { duration ->
-						OptionCard(
-							label = duration.label(),
-							icon = Icons.Outlined.Bedtime,
-							onClick = {
-								sleepTimerManager.startTimer(duration)
-								onDismissRequest(true)
-							},
-							modifier = Modifier.weight(1f)
-						)
-					}
-				}
-			} else {
-				Column(
-					modifier = Modifier.padding(horizontal = 16.dp),
-					verticalArrangement = Arrangement.spacedBy(8.dp)
-				) {
-					OptionCard(
-						label = stringResource(Res.string.action_sleep_timer_queue),
-						icon = Icons.Outlined.QueuePlayNext,
-						isActive = currentMode is SleepTimerMode.EndOfQueue,
-						onClick = {
-							sleepTimerManager.startEndOfQueueTimer()
-							onDismissRequest(true)
-						},
-						modifier = Modifier.fillMaxWidth()
-					)
-
+			when (selectedTab) {
+				SleepTimerTab.TIME -> {
 					FlowRow(
+						modifier = Modifier.padding(horizontal = 16.dp),
 						horizontalArrangement = Arrangement.spacedBy(8.dp),
 						verticalArrangement = Arrangement.spacedBy(8.dp),
 						maxItemsInEachRow = 3
 					) {
-						songCounts.forEach { count ->
+						durations.forEach { duration ->
 							OptionCard(
-								label = pluralStringResource(Res.plurals.count_songs, count, count),
-								icon = Icons.Outlined.Queue,
-								isActive = (currentMode as? SleepTimerMode.Songs)?.remaining == count,
+								label = duration.label(),
+								icon = Icons.Outlined.Bedtime,
 								onClick = {
-									sleepTimerManager.startSongsTimer(count)
+									sleepTimerManager.startTimer(duration)
 									onDismissRequest(true)
 								},
 								modifier = Modifier.weight(1f)
 							)
+						}
+					}
+				}
+				SleepTimerTab.SONGS -> {
+					Column(
+						modifier = Modifier.padding(horizontal = 16.dp),
+						verticalArrangement = Arrangement.spacedBy(8.dp)
+					) {
+						OptionCard(
+							label = stringResource(Res.string.action_sleep_timer_queue),
+							icon = Icons.Outlined.QueuePlayNext,
+							isActive = currentMode is SleepTimerMode.EndOfQueue,
+							onClick = {
+								sleepTimerManager.startEndOfQueueTimer()
+								onDismissRequest(true)
+							},
+							modifier = Modifier.fillMaxWidth()
+						)
+
+						FlowRow(
+							horizontalArrangement = Arrangement.spacedBy(8.dp),
+							verticalArrangement = Arrangement.spacedBy(8.dp),
+							maxItemsInEachRow = 3
+						) {
+							songCounts.forEach { count ->
+								OptionCard(
+									label = pluralStringResource(Res.plurals.count_songs, count, count),
+									icon = Icons.Outlined.Queue,
+									isActive = (currentMode as? SleepTimerMode.Songs)?.remaining == count,
+									onClick = {
+										sleepTimerManager.startSongsTimer(count)
+										onDismissRequest(true)
+									},
+									modifier = Modifier.weight(1f)
+								)
+							}
 						}
 					}
 				}

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/components/sheets/SleepTimerSheet.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/components/sheets/SleepTimerSheet.kt
@@ -2,9 +2,13 @@ package paige.navic.ui.components.sheets
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.add
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -14,19 +18,38 @@ import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.SheetValue
+import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import navic.composeapp.generated.resources.Res
 import navic.composeapp.generated.resources.action_disable_sleep_timer
 import navic.composeapp.generated.resources.action_sleep_timer
+import navic.composeapp.generated.resources.action_sleep_timer_queue
+import navic.composeapp.generated.resources.count_songs
+import navic.composeapp.generated.resources.title_sleep_timer_songs
+import navic.composeapp.generated.resources.title_sleep_timer_time
+import org.jetbrains.compose.resources.pluralStringResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.koinInject
 import paige.navic.domain.manager.SleepTimerManager
+import paige.navic.domain.manager.SleepTimerMode
+import paige.navic.icons.Icons
+import paige.navic.icons.outlined.Bedtime
+import paige.navic.icons.outlined.Queue
+import paige.navic.icons.outlined.QueuePlayNext
+import paige.navic.ui.components.common.OptionCard
 import paige.navic.util.core.label
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
@@ -40,18 +63,24 @@ val durations = listOf(
 	1.hours,
 )
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+val songCounts = listOf(1, 2, 3, 5, 10)
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class, ExperimentalLayoutApi::class)
 @Composable
 fun SleepTimerSheet(
 	onDismissRequest: (confirmed: Boolean) -> Unit
 ) {
-	val contentPadding = PaddingValues(horizontal = 16.dp)
-	val colors = ListItemDefaults.colors(
-		containerColor = Color.Transparent,
-		trailingIconColor = MaterialTheme.colorScheme.onSurface,
-		headlineColor = MaterialTheme.colorScheme.onSurface
-	)
 	val sleepTimerManager = koinInject<SleepTimerManager>()
+	val currentMode by sleepTimerManager.mode.collectAsState()
+
+	var selectedTab by remember(currentMode) {
+		mutableIntStateOf(
+			when (currentMode) {
+				is SleepTimerMode.Songs, SleepTimerMode.EndOfQueue -> 1
+				else -> 0
+			}
+		)
+	}
 
 	ModalBottomSheet(
 		onDismissRequest = { onDismissRequest(false) },
@@ -69,8 +98,10 @@ fun SleepTimerSheet(
 		}
 	) {
 		Column(
-			modifier = Modifier.verticalScroll(rememberScrollState()),
-			verticalArrangement = Arrangement.spacedBy(8.dp)
+			modifier = Modifier
+				.verticalScroll(rememberScrollState())
+				.padding(bottom = 16.dp),
+			verticalArrangement = Arrangement.spacedBy(16.dp)
 		) {
 			Text(
 				text = stringResource(Res.string.action_sleep_timer),
@@ -78,33 +109,95 @@ fun SleepTimerSheet(
 				modifier = Modifier.padding(horizontal = 16.dp)
 			)
 
-			durations.forEach {
-				ListItem(
-					content = { Text(it.label()) },
-					onClick = {
-						sleepTimerManager.startTimer(it)
-						onDismissRequest(true)
-					},
-					colors = colors,
-					contentPadding = contentPadding
+			PrimaryTabRow(
+				selectedTabIndex = selectedTab,
+				containerColor = Color.Transparent,
+				divider = {}
+			) {
+				Tab(
+					selected = selectedTab == 0,
+					onClick = { selectedTab = 0 },
+					text = { Text(stringResource(Res.string.title_sleep_timer_time)) }
+				)
+				Tab(
+					selected = selectedTab == 1,
+					onClick = { selectedTab = 1 },
+					text = { Text(stringResource(Res.string.title_sleep_timer_songs)) }
 				)
 			}
 
-			sleepTimerManager.endTimeStamp?.let {
-				ListItem(
-					content = {
-						Text(
-							stringResource(Res.string.action_disable_sleep_timer),
-							color = MaterialTheme.colorScheme.error
+			if (selectedTab == 0) {
+				FlowRow(
+					modifier = Modifier.padding(horizontal = 16.dp),
+					horizontalArrangement = Arrangement.spacedBy(8.dp),
+					verticalArrangement = Arrangement.spacedBy(8.dp),
+					maxItemsInEachRow = 3
+				) {
+					durations.forEach { duration ->
+						OptionCard(
+							label = duration.label(),
+							icon = Icons.Outlined.Bedtime,
+							onClick = {
+								sleepTimerManager.startTimer(duration)
+								onDismissRequest(true)
+							},
+							modifier = Modifier.weight(1f)
 						)
-					},
+					}
+				}
+			} else {
+				Column(
+					modifier = Modifier.padding(horizontal = 16.dp),
+					verticalArrangement = Arrangement.spacedBy(8.dp)
+				) {
+					OptionCard(
+						label = stringResource(Res.string.action_sleep_timer_queue),
+						icon = Icons.Outlined.QueuePlayNext,
+						isActive = currentMode is SleepTimerMode.EndOfQueue,
+						onClick = {
+							sleepTimerManager.startEndOfQueueTimer()
+							onDismissRequest(true)
+						},
+						modifier = Modifier.fillMaxWidth()
+					)
+
+					FlowRow(
+						horizontalArrangement = Arrangement.spacedBy(8.dp),
+						verticalArrangement = Arrangement.spacedBy(8.dp),
+						maxItemsInEachRow = 3
+					) {
+						songCounts.forEach { count ->
+							OptionCard(
+								label = pluralStringResource(Res.plurals.count_songs, count, count),
+								icon = Icons.Outlined.Queue,
+								isActive = (currentMode as? SleepTimerMode.Songs)?.remaining == count,
+								onClick = {
+									sleepTimerManager.startSongsTimer(count)
+									onDismissRequest(true)
+								},
+								modifier = Modifier.weight(1f)
+							)
+						}
+					}
+				}
+			}
+
+			if (currentMode !is SleepTimerMode.Disabled) {
+				Spacer(Modifier.height(8.dp))
+				ListItem(
 					onClick = {
 						sleepTimerManager.stopTimer()
 						onDismissRequest(true)
 					},
-					colors = colors,
-					contentPadding = contentPadding
-				)
+					colors = ListItemDefaults.colors(containerColor = Color.Transparent)
+				) {
+					Text(
+						stringResource(Res.string.action_disable_sleep_timer),
+						color = MaterialTheme.colorScheme.error,
+						modifier = Modifier.fillMaxWidth(),
+						textAlign = TextAlign.Center
+					)
+				}
 			}
 		}
 	}

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/components/sheets/SongSheet.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/components/sheets/SongSheet.kt
@@ -428,8 +428,8 @@ fun SongSheet(
 						},
 						leadingContent = {
 							Icon(
-								Icons.Outlined.Bedtime,
-								null,
+								imageVector = Icons.Outlined.Bedtime,
+								contentDescription = null,
 								tint = if (isEnabled) MaterialTheme.colorScheme.positive else MaterialTheme.colorScheme.onSurfaceVariant
 							)
 						},

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/components/sheets/SongSheet.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/components/sheets/SongSheet.kt
@@ -23,6 +23,8 @@ import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.buildAnnotatedString
@@ -41,6 +43,8 @@ import navic.composeapp.generated.resources.action_remove_star
 import navic.composeapp.generated.resources.action_share
 import navic.composeapp.generated.resources.action_sleep_timer
 import navic.composeapp.generated.resources.action_sleep_timer_enabled
+import navic.composeapp.generated.resources.action_sleep_timer_queue_enabled
+import navic.composeapp.generated.resources.action_sleep_timer_songs_enabled
 import navic.composeapp.generated.resources.action_star
 import navic.composeapp.generated.resources.action_track_info
 import navic.composeapp.generated.resources.action_view_album
@@ -54,6 +58,7 @@ import paige.navic.LocalNavStack
 import paige.navic.data.database.entities.DownloadStatus
 import paige.navic.domain.manager.PreferenceManager
 import paige.navic.domain.manager.SleepTimerManager
+import paige.navic.domain.manager.SleepTimerMode
 import paige.navic.domain.models.DomainAlbum
 import paige.navic.domain.models.DomainExplicitStatus
 import paige.navic.domain.models.DomainSong
@@ -117,7 +122,7 @@ fun SongSheet(
 	val preferenceManager = koinInject<PreferenceManager>()
 
 	val sleepTimerManager = koinInject<SleepTimerManager>()
-	val sleepTimerLeft = sleepTimerManager.timeLeft
+	val sleepTimerMode by sleepTimerManager.mode.collectAsState()
 	val contentPadding = PaddingValues(horizontal = 16.dp)
 
 	val colorScheme = if (useSongTheme) rememberColorSchemeFromCoverArt(song.coverArtId) else null
@@ -397,50 +402,43 @@ fun SongSheet(
 				}
 
 				if (showSleepTimer) {
-					if (sleepTimerLeft != null) {
-						ListItem(
-							content = {
-								Text(
-									stringResource(
+					val isEnabled = sleepTimerMode !is SleepTimerMode.Disabled
+					ListItem(
+						content = {
+							Text(
+								text = when (val mode = sleepTimerMode) {
+									is SleepTimerMode.Time -> stringResource(
 										Res.string.action_sleep_timer_enabled,
-										sleepTimerLeft.label()
-									),
-									color = MaterialTheme.colorScheme.positive
-								)
-							},
-							leadingContent = {
-								Icon(
-									Icons.Outlined.Bedtime,
-									null,
-									tint = MaterialTheme.colorScheme.positive
-								)
-							},
-							onClick = {
-								onSleepTimer?.invoke()
-							},
-							colors = colors,
-							contentPadding = contentPadding
-						)
-					} else {
-						ListItem(
-							content = {
-								Text(
-									stringResource(Res.string.action_sleep_timer)
-								)
-							},
-							leadingContent = {
-								Icon(
-									Icons.Outlined.Bedtime,
-									null
-								)
-							},
-							onClick = {
-								onSleepTimer?.invoke()
-							},
-							colors = colors,
-							contentPadding = contentPadding
-						)
-					}
+										sleepTimerManager.timeLeft?.label() ?: ""
+									)
+
+									is SleepTimerMode.Songs -> stringResource(
+										Res.string.action_sleep_timer_songs_enabled,
+										mode.remaining
+									)
+
+									is SleepTimerMode.EndOfQueue -> stringResource(
+										Res.string.action_sleep_timer_queue_enabled
+									)
+
+									else -> stringResource(Res.string.action_sleep_timer)
+								},
+								color = if (isEnabled) MaterialTheme.colorScheme.positive else Color.Unspecified
+							)
+						},
+						leadingContent = {
+							Icon(
+								Icons.Outlined.Bedtime,
+								null,
+								tint = if (isEnabled) MaterialTheme.colorScheme.positive else MaterialTheme.colorScheme.onSurfaceVariant
+							)
+						},
+						onClick = {
+							onSleepTimer?.invoke()
+						},
+						colors = colors,
+						contentPadding = contentPadding
+					)
 				}
 
 				if (showPlaybackSpeed) {

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/components/sheets/SongSheet.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/components/sheets/SongSheet.kt
@@ -23,12 +23,12 @@ import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.compose.dropUnlessResumed
 import navic.composeapp.generated.resources.Res
 import navic.composeapp.generated.resources.action_add_to_another_playlist
@@ -122,7 +122,7 @@ fun SongSheet(
 	val preferenceManager = koinInject<PreferenceManager>()
 
 	val sleepTimerManager = koinInject<SleepTimerManager>()
-	val sleepTimerMode by sleepTimerManager.mode.collectAsState()
+	val sleepTimerMode by sleepTimerManager.mode.collectAsStateWithLifecycle()
 	val contentPadding = PaddingValues(horizontal = 16.dp)
 
 	val colorScheme = if (useSongTheme) rememberColorSchemeFromCoverArt(song.coverArtId) else null


### PR DESCRIPTION
Added the possibility to set timer by songs/queue and made its ui better:

|old|new for time|new for songs|
|-|-|-|
|![Image](https://github.com/user-attachments/assets/8c136150-6a95-4dd3-b088-978b70afb7bb)| ![Image](https://github.com/user-attachments/assets/d10be3c1-5534-4821-867e-417196578336)| ![Image](https://github.com/user-attachments/assets/c56276c5-b03d-4e2b-b1a7-0f38eb4daf1c)|

Also made it so you can view the remaining time/songs in the sheet itself:

|when setting time|when setting songs|
|-|-|
|![Image](https://github.com/user-attachments/assets/a7a3b97e-58de-421f-9588-d5756a270f32)| ![Image](https://github.com/user-attachments/assets/29439ba9-2361-49d7-a690-ebcfe99f740e)|

closes #446 

I'm back :)