### PR TITLE
fix: untimed lyrics

### DIFF
--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/lyrics/components/Content.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/lyrics/components/Content.kt
@@ -197,6 +197,7 @@ fun LyricsScreenContent(
 				text = line.text,
 				progress = progress,
 				isActive = highlight,
+				isSynced = isSynced,
 				onClick = {
 					if (isSelecting) {
 						val lineTextLength = line.text.length
@@ -233,8 +234,8 @@ fun LyricsScreenContent(
 								}
 							}
 						}
-					} else {
-						player.seek((lineTime / duration).toFloat())
+					} else if (line.time != null) {
+						player.seek((line.time / duration).toFloat())
 						if (player.uiState.value.isPaused) {
 							player.resume()
 						}

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/lyrics/components/KaraokeText.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/lyrics/components/KaraokeText.kt
@@ -38,6 +38,7 @@ fun LyricsScreenKaraokeText(
 	text: String,
 	progress: Float,
 	isActive: Boolean,
+	isSynced: Boolean,
 	onClick: () -> Unit,
 	modifier: Modifier = Modifier
 ) {
@@ -59,7 +60,11 @@ fun LyricsScreenKaraokeText(
 		}
 	} ?: false
 
-	val inactiveAlpha = if (lyricsBrightInactive) 0.9f else 0.35f
+	val inactiveAlpha = when {
+		!isSynced -> 1f
+		lyricsBrightInactive -> 0.9f
+		else -> 0.35f
+	}
 
 	val alphaTransition by animateFloatAsState(
 		targetValue = if (isActive) 1f else inactiveAlpha,
@@ -70,7 +75,7 @@ fun LyricsScreenKaraokeText(
 		Text(
 			text = text,
 			fontSize = 32.sp,
-			fontWeight = FontWeight.Bold,
+			fontWeight = if (isActive) FontWeight.Bold else FontWeight.SemiBold,
 			textAlign = if (isRtl) TextAlign.End else TextAlign.Start,
 			style = MaterialTheme.typography.headlineLargeEmphasized,
 			color = if (lyricsBrightInactive) Color.White.copy(alpha = alphaTransition * 0.4f)


### PR DESCRIPTION
Untimed lyrics are now semibold instead of normal bold for active ones, and clicking them won't reset the song.

closes #487 