### PR TITLE
optimize exoplayer a little

### DIFF
--- a/composeApp/src/androidMain/kotlin/paige/navic/shared/MediaPlayer.android.kt
+++ b/composeApp/src/androidMain/kotlin/paige/navic/shared/MediaPlayer.android.kt
@@ -21,7 +21,6 @@ import androidx.media3.common.Player
 import androidx.media3.common.Timeline
 import androidx.media3.common.TrackSelectionParameters
 import androidx.media3.common.Tracks
-import androidx.media3.common.util.ExperimentalApi
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DefaultHttpDataSource
@@ -118,7 +117,6 @@ class PlaybackService : MediaSessionService(), KoinComponent {
 	private var currentAudioSessionId: Int = C.AUDIO_SESSION_ID_UNSET
 	private var equaliserMode: EqualiserMode = EqualiserMode.Disabled
 
-	@ExperimentalApi
 	override fun onCreate() {
 		super.onCreate()
 		val loadControl = DefaultLoadControl.Builder()
@@ -173,7 +171,6 @@ class PlaybackService : MediaSessionService(), KoinComponent {
 			.setLoadControl(loadControl)
 			.setMediaSourceFactory(mediaSourceFactory)
 			.setHandleAudioBecomingNoisy(true)
-			.enablePerStreamMediaProgression(true)
 			.setWakeMode(C.WAKE_MODE_NETWORK)
 			.build()
 			.apply {

--- a/composeApp/src/androidMain/kotlin/paige/navic/shared/MediaPlayer.android.kt
+++ b/composeApp/src/androidMain/kotlin/paige/navic/shared/MediaPlayer.android.kt
@@ -33,10 +33,16 @@ import androidx.media3.exoplayer.audio.DefaultAudioSink
 import androidx.media3.exoplayer.audio.MediaCodecAudioRenderer
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
-import androidx.media3.extractor.DefaultExtractorsFactory
+import androidx.media3.extractor.ExtractorsFactory
 import androidx.media3.extractor.flac.FlacExtractor
+import androidx.media3.extractor.mkv.MatroskaExtractor
 import androidx.media3.extractor.mp3.Mp3Extractor
+import androidx.media3.extractor.mp4.FragmentedMp4Extractor
 import androidx.media3.extractor.mp4.Mp4Extractor
+import androidx.media3.extractor.ogg.OggExtractor
+import androidx.media3.extractor.text.DefaultSubtitleParserFactory
+import androidx.media3.extractor.ts.AdtsExtractor
+import androidx.media3.extractor.wav.WavExtractor
 import androidx.media3.session.CommandButton
 import androidx.media3.session.DefaultMediaNotificationProvider
 import androidx.media3.session.MediaController
@@ -134,10 +140,18 @@ class PlaybackService : MediaSessionService(), KoinComponent {
 			.setDefaultRequestProperties(preferenceManager.customHeadersMap())
 		val dataSourceFactory = DefaultDataSource.Factory(this, httpDataSourceFactory)
 
-		val extractorsFactory = DefaultExtractorsFactory()
-			.setMp3ExtractorFlags(Mp3Extractor.FLAG_DISABLE_ID3_METADATA)
-			.setFlacExtractorFlags(FlacExtractor.FLAG_DISABLE_ID3_METADATA)
-			.setDisableArtworkMetadata(true)
+		val extractorsFactory = ExtractorsFactory {
+			arrayOf(
+				FlacExtractor(),
+				WavExtractor(),
+				FragmentedMp4Extractor(DefaultSubtitleParserFactory.UNSUPPORTED),
+				Mp4Extractor(DefaultSubtitleParserFactory.UNSUPPORTED),
+				OggExtractor(),
+				MatroskaExtractor(DefaultSubtitleParserFactory.UNSUPPORTED),
+				AdtsExtractor(AdtsExtractor.FLAG_ENABLE_CONSTANT_BITRATE_SEEKING),
+				Mp3Extractor(Mp3Extractor.FLAG_ENABLE_CONSTANT_BITRATE_SEEKING)
+			)
+		}
 
 		val mediaSourceFactory = DefaultMediaSourceFactory(dataSourceFactory, extractorsFactory)
 

--- a/composeApp/src/androidMain/kotlin/paige/navic/shared/MediaPlayer.android.kt
+++ b/composeApp/src/androidMain/kotlin/paige/navic/shared/MediaPlayer.android.kt
@@ -21,6 +21,7 @@ import androidx.media3.common.Player
 import androidx.media3.common.Timeline
 import androidx.media3.common.TrackSelectionParameters
 import androidx.media3.common.Tracks
+import androidx.media3.common.util.ExperimentalApi
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DefaultHttpDataSource
@@ -111,6 +112,7 @@ class PlaybackService : MediaSessionService(), KoinComponent {
 	private var currentAudioSessionId: Int = C.AUDIO_SESSION_ID_UNSET
 	private var equaliserMode: EqualiserMode = EqualiserMode.Disabled
 
+	@ExperimentalApi
 	override fun onCreate() {
 		super.onCreate()
 		val loadControl = DefaultLoadControl.Builder()
@@ -157,6 +159,7 @@ class PlaybackService : MediaSessionService(), KoinComponent {
 			.setLoadControl(loadControl)
 			.setMediaSourceFactory(mediaSourceFactory)
 			.setHandleAudioBecomingNoisy(true)
+			.enablePerStreamMediaProgression(true)
 			.setWakeMode(C.WAKE_MODE_NETWORK)
 			.build()
 			.apply {

--- a/composeApp/src/androidMain/kotlin/paige/navic/shared/MediaPlayer.android.kt
+++ b/composeApp/src/androidMain/kotlin/paige/navic/shared/MediaPlayer.android.kt
@@ -32,6 +32,10 @@ import androidx.media3.exoplayer.audio.DefaultAudioSink
 import androidx.media3.exoplayer.audio.MediaCodecAudioRenderer
 import androidx.media3.exoplayer.mediacodec.MediaCodecSelector
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.extractor.DefaultExtractorsFactory
+import androidx.media3.extractor.flac.FlacExtractor
+import androidx.media3.extractor.mp3.Mp3Extractor
+import androidx.media3.extractor.mp4.Mp4Extractor
 import androidx.media3.session.CommandButton
 import androidx.media3.session.DefaultMediaNotificationProvider
 import androidx.media3.session.MediaController
@@ -127,7 +131,13 @@ class PlaybackService : MediaSessionService(), KoinComponent {
 		val httpDataSourceFactory = DefaultHttpDataSource.Factory()
 			.setDefaultRequestProperties(preferenceManager.customHeadersMap())
 		val dataSourceFactory = DefaultDataSource.Factory(this, httpDataSourceFactory)
-		val mediaSourceFactory = DefaultMediaSourceFactory(dataSourceFactory)
+
+		val extractorsFactory = DefaultExtractorsFactory()
+			.setMp3ExtractorFlags(Mp3Extractor.FLAG_DISABLE_ID3_METADATA)
+			.setFlacExtractorFlags(FlacExtractor.FLAG_DISABLE_ID3_METADATA)
+			.setDisableArtworkMetadata(true)
+
+		val mediaSourceFactory = DefaultMediaSourceFactory(dataSourceFactory, extractorsFactory)
 
 		val audioRenderer = RenderersFactory { handler, _, audioListener, _, _ ->
 			arrayOf<BaseRenderer>(


### PR DESCRIPTION
this disables the unnecessary metadata and artwork parsing from exoplayer, and enables per stream media progression, which should hopefully make things like gapless playback, well, more gapless, and also prevent buffering when the next track starts playing when transcoding is enabled for streaming 

this needs more testing