### PR TITLE
fix: set genres cars to 2, closes #520

### DIFF
--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/components/layouts/ArtGrid.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/components/layouts/ArtGrid.kt
@@ -57,12 +57,13 @@ fun ArtGrid(
 	horizontalArrangement: Arrangement.Horizontal = Arrangement.spacedBy(12.dp),
 	verticalArrangement: Arrangement.Vertical = Arrangement.spacedBy(12.dp),
 	selectedViewMode: ListViewMode = ListViewMode.Grid,
+	columns: GridCells? = null,
 	content: LazyGridScope.() -> Unit
 ) {
 	val platformContext = LocalPlatformContext.current
 	val preferenceManager = koinInject<PreferenceManager>()
 	val artGridItemSize = preferenceManager.artGridItemSize
-	val columns = if (selectedViewMode == ListViewMode.List) {
+	val gridColumns = columns ?: if (selectedViewMode == ListViewMode.List) {
 		GridCells.Fixed(1)
 	} else if (platformContext.sizeClass.widthSizeClass <= WindowWidthSizeClass.Compact) {
 		GridCells.Fixed(preferenceManager.gridSize.value)
@@ -72,7 +73,7 @@ fun ArtGrid(
 	LazyVerticalGrid(
 		modifier = modifier.fillMaxSize(),
 		state = state,
-		columns = columns,
+		columns = gridColumns,
 		contentPadding = if (selectedViewMode == ListViewMode.Grid) {
 			contentPadding + PaddingValues(
 				start = 16.dp,

--- a/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/genre/GenreListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/ui/screens/genre/GenreListScreen.kt
@@ -3,6 +3,7 @@ package paige.navic.ui.screens.genre
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.MaterialTheme
@@ -90,7 +91,8 @@ fun GenreListScreen(
 				state = viewModel.gridState,
 				verticalArrangement = if ((genresState as? UiState.Success)?.data?.isEmpty() == true)
 					Arrangement.Center
-				else Arrangement.spacedBy(12.dp)
+				else Arrangement.spacedBy(12.dp),
+				columns = GridCells.Fixed(2)
 			) {
 				genreListScreenContent(state = genresState)
 			}


### PR DESCRIPTION
<!--
I do not accept pull requests which were written or assisted with an LLM.
Your PR will be closed and you will be blocked from this repository if I
suspect you are using an LLM.
-->

## Describe your changes (and why you made them)

made columns in GenreListScreen be always 2, let me know if it should be dynamic but i don't think so

<!-- If this PR addresses an issue, you may want to link that issue here: -->
Closes: #520 

## Screenshots (if applicable)

<!--
Please make the screenshots use <img> and set the width to 400 so that
the screenshots don't appear huge on the pull request page. For example,
this:

![Image](https://github.com/user-attachments/assets/b18ff82b-cb63-45d6-9d8a-f4de9510918f)

should be this:

<img width="400" src="https://github.com/user-attachments/assets/b18ff82b-cb63-45d6-9d8a-f4de9510918f">

(You don't need to do this, but it would be appreciated)
 -->

## Checklist

<!-- Use [x] to tick the boxes. -->

- [X] This pull request adheres to the rules and conventions in [CONTRIBUTING.md](https://github.com/ssalggnikool/Navic/blob/master/.github/CONTRIBUTING.md)
- [X] This pull request was not assisted with an LLM
