### PR TITLE
fix: android notification showing album artist instead of track artist

### DIFF
--- a/composeApp/src/androidMain/kotlin/paige/navic/shared/MediaPlayer.android.kt
+++ b/composeApp/src/androidMain/kotlin/paige/navic/shared/MediaPlayer.android.kt
@@ -501,21 +501,26 @@ class AndroidMediaPlayerViewModel(
 
 					override fun onIsPlayingChanged(isPlaying: Boolean) {
 						if (isPlaying) startProgressLoop()
+
+						val currentSong = _uiState.value.currentSong
+						val displayArtist = currentSong?.artists?.joinToString { it.name }
+							?.ifBlank { currentSong.artistName }
+
 						val intent =
 							Intent("${application.packageName}.NOW_PLAYING_UPDATED").apply {
 								setPackage(application.packageName)
 								putExtra("isPlaying", isPlaying)
 								putExtra(
 									"title",
-									_uiState.value.currentSong?.title ?: "Unknown song"
+									currentSong?.title ?: "Unknown song"
 								)
 								putExtra(
 									"artist",
-									_uiState.value.currentSong?.artistName ?: "Unknown artist"
+									displayArtist ?: "Unknown artist"
 								)
 								putExtra(
 									"artUrl",
-									_uiState.value.currentSong?.coverArtId?.let {
+									currentSong?.coverArtId?.let {
 										sessionManager.getCoverArtUrl(it)
 									})
 							}
@@ -1111,10 +1116,14 @@ class AndroidMediaPlayerViewModel(
 	}
 
 	private fun DomainSong.toMediaItem(): MediaItem {
+		val displayArtist = artists.joinToString { it.name }.ifBlank { artistName }
+		val albumArtistName = albumArtists.joinToString { it.name }.ifBlank { artistName }
+
 		val metadataBuilder = MediaMetadata.Builder()
 			.setTitle(title)
-			.setSubtitle(artistName)
-			.setArtist(artistName)
+			.setSubtitle(displayArtist)
+			.setArtist(displayArtist)
+			.setAlbumArtist(albumArtistName)
 			.setAlbumTitle(albumTitle)
 			.setDurationMs(duration.inWholeMilliseconds)
 			.setMediaType(MediaMetadata.MEDIA_TYPE_MUSIC)

--- a/composeApp/src/commonMain/kotlin/paige/navic/domain/repositories/DbRepository.kt
+++ b/composeApp/src/commonMain/kotlin/paige/navic/domain/repositories/DbRepository.kt
@@ -227,8 +227,8 @@ class DbRepository(
 
 					album.songs.forEach { song ->
 						val songEntity = song.toEntity(
-							artistIdOverride = albumEntity.artistId,
-							artistNameOverride = albumEntity.artistName
+							artistIdOverride = albumEntity.artistId.takeIf { song.artistId.isNullOrBlank() },
+							artistNameOverride = albumEntity.artistName.takeIf { song.artistName.isBlank() }
 						)
 						songBatch.add(songEntity)
 						allValidSongIds.add(songEntity.songId)


### PR DESCRIPTION
<!--
I do not accept pull requests which were written or assisted with an LLM.
Your PR will be closed and you will be blocked from this repository if I
suspect you are using an LLM.
-->

## Describe your changes (and why you made them)

<!-- If this PR addresses an issue, you may want to link that issue here: -->
Closes: #526 

made the android mediaplayer display the artist correctly, also made it so in DbRepository that the artistId and artistName override works only if song fields are empty.

## Checklist

<!-- Use [x] to tick the boxes. -->

- [X] This pull request adheres to the rules and conventions in [CONTRIBUTING.md](https://github.com/ssalggnikool/Navic/blob/master/.github/CONTRIBUTING.md)
- [X] This pull request was not assisted with an LLM
